### PR TITLE
Filter out main modules

### DIFF
--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -30,8 +30,8 @@ import (
 
 var _ = Describe("Internal", func() {
 	var (
-		tmpDir                                                   string
-		moduleA, moduleB, moduleB1, moduleB11, moduleB2, moduleC Module
+		tmpDir                                                            string
+		moduleA, moduleB, moduleB1, moduleB11, moduleB2, moduleC, moduleD Module
 	)
 	BeforeEach(func() {
 		var err error
@@ -41,6 +41,7 @@ var _ = Describe("Internal", func() {
 		moduleA = Module{
 			Path: "a",
 			Dir:  "/tmp/a",
+			Main: true,
 		}
 		moduleB = Module{
 			Path: "example.org/b",
@@ -61,6 +62,9 @@ var _ = Describe("Internal", func() {
 		moduleC = Module{
 			Path: "example.org/user/c",
 			Dir:  "/tmp/example.org/user/c",
+		}
+		moduleD = Module{
+			Path: "example.org/d",
 		}
 	})
 	AfterEach(func() {
@@ -146,7 +150,14 @@ var _ = Describe("Internal", func() {
 			mods, err := ParseModules(bytes.NewReader(data))
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(mods).To(Equal([]Module{moduleA, moduleB}))
+			Expect(mods).To(Equal([]Module{moduleA, moduleB, moduleD}))
+		})
+	})
+
+	Describe("FilterVendorModules", func() {
+		It("should correctly filter the modules", func() {
+			mods := FilterVendorModules([]Module{moduleA, moduleB, moduleD})
+			Expect(mods).To(Equal([]Module{moduleB}))
 		})
 	})
 

--- a/internal/testdata/modules.json.stream
+++ b/internal/testdata/modules.json.stream
@@ -1,6 +1,7 @@
 {
 	"Path": "a",
-	"Dir": "/tmp/a"
+	"Dir": "/tmp/a",
+	"Main": true
 }
 {
 	"Path": "example.org/b",


### PR DESCRIPTION
This fixes an issue with multi-module projects that accidentially vendored main modules, causing already-exists errors when symlinking.

The same strategy is employed by go in the `go mod vendor` command, see https://github.com/golang/go/blob/81efd7b347dd6d7f12fd49c6eee0274005734c71/src/cmd/go/internal/modcmd/vendor.go#L100